### PR TITLE
UI Fixes

### DIFF
--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
@@ -26,6 +26,7 @@ package dji.sampleV5.aircraft.defaultlayout;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import android.widget.Button;
 
 import androidx.annotation.Nullable;
@@ -116,6 +117,7 @@ public class DefaultLayoutActivity extends AppCompatActivity {
     private VideoChannelStateChangeListener primaryChannelStateListener = null;
     private VideoChannelStateChangeListener secondaryChannelStateListener = null;
     private Button liveStreamButton;
+    private Button mapExpand;
     //endregion
 
     //region Lifecycle
@@ -151,7 +153,7 @@ public class DefaultLayoutActivity extends AppCompatActivity {
 //        if (stub != null) {
 //            mSettingPanelWidget = (SettingPanelWidget) stub.inflate();
 //        }
-
+        mapExpand = (Button) findViewById(R.id.button_expand_map);
         liveStreamButton = (Button) findViewById(R.id.myLiveStream) ;
         streamManager = new StreamManager();
 
@@ -210,7 +212,28 @@ public class DefaultLayoutActivity extends AppCompatActivity {
                     }
                 }
             });
-        };
+        }
+        if (mapExpand != null && mapWidget != null) {
+            mapExpand.setOnClickListener(new View.OnClickListener() {
+                final int mapWidth = getResources().getDimensionPixelSize(R.dimen.uxsdk_150_dp);
+                final int mapHeight = getResources().getDimensionPixelSize(R.dimen.uxsdk_100_dp);
+                @Override
+                public void onClick(View view) {
+                    ViewGroup.LayoutParams params = mapWidget.getLayoutParams();
+                    if (params.width == mapWidth) {
+                        params.height = primaryFpvWidget.getHeight() - (topBarPanel.getBottom() + getResources().getDimensionPixelSize(R.dimen.uxsdk_12_dp));
+                        params.width = primaryFpvWidget.getWidth() - getResources().getDimensionPixelSize(R.dimen.uxsdk_24_dp);
+                        mapExpand.setRotation(0);
+                    }
+                    else {
+                        params.height = mapHeight;
+                        params.width = mapWidth;
+                        mapExpand.setRotation(180);
+                    }
+                    mapWidget.setLayoutParams(params);
+                }
+            });
+        }
     }
 
     private void toggleRightDrawer() {

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/cameracore/widget/cameracontrols/lenscontrol/LensControlWidget.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/cameracore/widget/cameracontrols/lenscontrol/LensControlWidget.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import android.widget.Button
+import androidx.core.content.ContextCompat
 import dji.sdk.keyvalue.value.camera.CameraVideoStreamSourceType
 import dji.sdk.keyvalue.value.common.CameraLensType
 import dji.sdk.keyvalue.value.common.ComponentIndexType
@@ -34,6 +35,7 @@ open class LensControlWidget @JvmOverloads constructor(
 
     private var firstBtnSource = CameraVideoStreamSourceType.ZOOM_CAMERA
     private var secondBtnSource = CameraVideoStreamSourceType.WIDE_CAMERA
+    private var thirdBtnSource = CameraVideoStreamSourceType.INFRARED_CAMERA
 
     private val widgetModel by lazy {
         LensControlModel(DJISDKModel.getInstance(), ObservableInMemoryKeyedStore.getInstance())
@@ -52,6 +54,7 @@ open class LensControlWidget @JvmOverloads constructor(
         })
         first_len_btn.setOnClickListener(this)
         second_len_btn.setOnClickListener(this)
+        third_len_btn.setOnClickListener(this)
     }
 
     override fun onAttachedToWindow() {
@@ -75,8 +78,19 @@ open class LensControlWidget @JvmOverloads constructor(
     override fun onClick(v: View?) {
         if (v == first_len_btn) {
             dealLensBtnClicked(firstBtnSource)
+            first_len_btn.setBackgroundResource(R.color.uxsdk_dic_color_c10_light_sea_blue)
+            second_len_btn.setBackgroundResource(R.color.uxsdk_black_70_percent)
+            third_len_btn.setBackgroundResource(R.color.uxsdk_black_70_percent)
         } else if (v == second_len_btn) {
             dealLensBtnClicked(secondBtnSource)
+            first_len_btn.setBackgroundResource(R.color.uxsdk_black_70_percent)
+            second_len_btn.setBackgroundResource(R.color.uxsdk_dic_color_c10_light_sea_blue)
+            third_len_btn.setBackgroundResource(R.color.uxsdk_black_70_percent)
+        } else if (v == third_len_btn) {
+            dealLensBtnClicked(thirdBtnSource)
+            first_len_btn.setBackgroundResource(R.color.uxsdk_black_70_percent)
+            second_len_btn.setBackgroundResource(R.color.uxsdk_black_70_percent)
+            third_len_btn.setBackgroundResource(R.color.uxsdk_dic_color_c10_light_sea_blue)
         }
     }
 
@@ -98,31 +112,12 @@ open class LensControlWidget @JvmOverloads constructor(
         addDisposable(widgetModel.setCameraVideoStreamSource(source).observeOn(ui()).subscribe())
     }
 
+    // only for button initialization - when camera views are available, set the button to be that camera
     private fun updateBtnView() {
         val videoSourceRange = widgetModel.properCameraVideoStreamSourceRangeProcessor.value
-        //单源
-        if (videoSourceRange.size <= 1) {
-            first_len_btn.visibility = INVISIBLE
-            second_len_btn.visibility = INVISIBLE
-            return
-        }
-        first_len_btn.visibility = VISIBLE
-        //双源
-        if (videoSourceRange.size == 2) {
-            updateBtnText(first_len_btn, getProperVideoSource(videoSourceRange,widgetModel.cameraVideoStreamSourceProcessor.value).also {
-                firstBtnSource = it
-            })
-            second_len_btn.visibility = INVISIBLE
-            return
-        }
-        //超过2个源
-        second_len_btn.visibility = VISIBLE
-        updateBtnText(first_len_btn, getProperVideoSource(videoSourceRange, secondBtnSource).also {
-            firstBtnSource = it
-        })
-        updateBtnText(second_len_btn, getProperVideoSource(videoSourceRange, firstBtnSource).also {
-            secondBtnSource = it
-        })
+        updateBtnText(first_len_btn, getProperVideoSource(videoSourceRange, firstBtnSource))
+        updateBtnText(second_len_btn, getProperVideoSource(videoSourceRange, secondBtnSource))
+        updateBtnText(third_len_btn, getProperVideoSource(videoSourceRange, thirdBtnSource))
     }
 
     private fun updateBtnText(button: Button, source: CameraVideoStreamSourceType) {
@@ -138,7 +133,7 @@ open class LensControlWidget @JvmOverloads constructor(
 
     private fun getProperVideoSource(range: List<CameraVideoStreamSourceType>, exceptSource: CameraVideoStreamSourceType): CameraVideoStreamSourceType {
         for (source in range) {
-            if (source != widgetModel.cameraVideoStreamSourceProcessor.value && source != exceptSource) {
+            if (source != widgetModel.cameraVideoStreamSourceProcessor.value && source == exceptSource) {
                 return source
             }
         }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/layout/uxsdk_activity_default_layout.xml
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/layout/uxsdk_activity_default_layout.xml
@@ -181,7 +181,7 @@
             android:layout_height="wrap_content"
             android:visibility="invisible"
             app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toStartOf="@id/widget_camera_controls"
+            app:layout_constraintStart_toEndOf="@+id/widget_lens_control"
             app:layout_constraintTop_toBottomOf="@+id/widget_focus_exposure_switch"
             app:layout_constraintVertical_bias="0.05" />
 
@@ -201,41 +201,42 @@
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginStart="12dp"
-            android:layout_marginTop="125dp"
+            android:layout_marginTop="5dp"
             android:layout_marginBottom="5dp"
             android:padding="3dp"
-            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintBottom_toTopOf="@+id/widget_return_to_home"
             app:layout_constraintDimensionRatio="@string/uxsdk_widget_default_ratio"
             app:layout_constraintHeight_percent="0.1"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/widget_return_to_home"
             app:layout_constraintVertical_bias="0.3"
             tools:ignore="SpeakableTextPresentCheck,TouchTargetSizeCheck" />
 
         <dji.v5.ux.cameracore.widget.cameracontrols.lenscontrol.LensControlWidget
             android:id="@+id/widget_lens_control"
             android:layout_width="@dimen/uxsdk_76_dp"
-            android:layout_height="@dimen/uxsdk_95_dp"
+            android:layout_height="@dimen/uxsdk_155_dp"
             android:layout_marginStart="12dp"
-            android:layout_marginTop="125dp"
+            android:layout_marginTop="26dp"
             android:padding="3dp"
             app:layout_constraintStart_toEndOf="@id/widget_take_off"
-            app:layout_constraintTop_toBottomOf="@id/widget_remaining_flight_time" />
+            app:layout_constraintTop_toBottomOf="@+id/myLiveStream"
+            app:layout_constraintStart_toStartOf="parent"/>
 
         <dji.v5.ux.flight.returnhome.ReturnHomeWidget
             android:id="@+id/widget_return_to_home"
             android:layout_width="0dp"
             android:layout_height="0dp"
             android:layout_marginStart="12dp"
-            android:layout_marginTop="5dp"
-            android:layout_marginBottom="5dp"
+            android:layout_marginTop="1dp"
+            android:layout_marginBottom="12dp"
             android:padding="3dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintDimensionRatio="@string/uxsdk_widget_default_ratio"
             app:layout_constraintHeight_percent="0.1"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/widget_take_off"
-            app:layout_constraintVertical_bias="0"
+            app:layout_constraintTop_toBottomOf="@id/widget_take_off"
+            app:layout_constraintVertical_bias="0.3"
             tools:ignore="TouchTargetSizeCheck,SpeakableTextPresentCheck" />
 
         <dji.v5.ux.training.simulatorcontrol.SimulatorControlWidget
@@ -243,6 +244,7 @@
             android:layout_width="330dp"
             android:layout_height="0dp"
             android:visibility="invisible"
+            android:elevation="12dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
@@ -264,10 +266,21 @@
             android:layout_height="@dimen/uxsdk_100_dp"
             android:layout_marginEnd="12dp"
             android:layout_marginBottom="12dp"
-
+            android:elevation="11dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:uxsdk_djiMap_mapType="normal" />
+            app:uxsdk_djiMap_mapType="normal">
+            <Button
+                android:id="@+id/button_expand_map"
+                android:layout_width="30dp"
+                android:layout_height="30dp"
+                android:background="@drawable/uxsdk_ic_spinner_cell_expand"
+                android:rotation="180"
+                android:elevation="10dp"
+                android:foreground="?selectableItemBackground"
+                android:padding="8dp"
+                tools:layout_editor_absoluteY="1387dp" />
+    </dji.v5.ux.map.MapWidget>
 
         <dji.v5.ux.core.panel.systemstatus.SystemStatusListPanelWidget
             android:id="@+id/widget_panel_system_status_list"
@@ -281,28 +294,29 @@
             android:paddingEnd="@dimen/uxsdk_spacing_normal"
             android:paddingRight="@dimen/uxsdk_spacing_normal"
             android:visibility="invisible"
+            android:elevation="12dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintWidth_percent="0.95"
-            app:uxsdk_titleBarBackgroundColor="@color/uxsdk_black" />
+            app:uxsdk_titleBarBackgroundColor="@color/uxsdk_black"/>
 
         <Button
             android:id="@+id/myLiveStream"
             android:layout_width="30dp"
             android:layout_height="30dp"
+            android:layout_marginLeft="10dp"
+            android:layout_marginTop="60dp"
+            android:background="@drawable/uxsdk_livestream_start"
             android:elevation="10dp"
             android:foreground="?selectableItemBackground"
             android:padding="8dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_bias="0"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintVertical_bias="0"
-            app:layout_constraintHorizontal_bias="0"
-            android:layout_marginTop="100dp"
-            android:layout_marginLeft="10dp"
-            android:background="@drawable/uxsdk_livestream_start" />
+            app:layout_constraintVertical_bias="0" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/layout/uxsdk_camera_lens_control_widget.xml
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/layout/uxsdk_camera_lens_control_widget.xml
@@ -15,8 +15,10 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintBottom_toTopOf="@id/second_len_btn"
+        app:layout_constraintDimensionRatio="1:1"
+        android:background="#80000000"
         android:text="first"
-        android:textColor="@color/uxsdk_black"
+        android:textColor="@color/uxsdk_white"
         android:textSize="@dimen/uxsdk_text_size_normal_medium" />
 
     <Button
@@ -26,9 +28,25 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/first_len_btn"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toBottomOf="@id/third_len_btn"
+        app:layout_constraintDimensionRatio="1:1"
+        android:background="#80000000"
         android:text="second"
-        android:textColor="@color/uxsdk_black"
+        android:textColor="@color/uxsdk_white"
+        android:textSize="@dimen/uxsdk_text_size_normal_medium" />
+
+    <Button
+        android:id="@+id/third_len_btn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/second_len_btn"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintDimensionRatio="1:1"
+        android:background="@color/uxsdk_black_70_percent"
+        android:text="third"
+        android:textColor="@color/uxsdk_white"
         android:textSize="@dimen/uxsdk_text_size_normal_medium" />
 
 </merge>


### PR DESCRIPTION
Several changes have been made to the RINAO_Android_App - all of which are listed below.
- Camera selection widget has changed from two buttons to three, constant with the number of camera inputs for the drone.
- The zoom widget has moved so that it is next to the camera selection widget - done so the bottom portion of it is not obscured from the map.
- Take off and return to home widgets moved to the bottom of the screen to make room for larger camera selection widget.
- Livestream button has moved to the top of the screen to make room for larger camera selection widget.
- Button to expand/contract the map has been added to the top-left corner of the map

Some of these changes are reflected in the screenshot below (some buttons are not visible since this is a screenshot of a sim, and is not actually connected to the drone).
<img width="539" alt="Screenshot 2024-02-18 at 6 21 43 PM" src="https://github.com/hmray2025/RINAO_Android_App/assets/89418308/ac271856-29a7-44ea-a73a-52374f514058">
