### PR TITLE
Bug fixes

### DIFF
--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/DJIAircraftMainActivity.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/DJIAircraftMainActivity.kt
@@ -4,7 +4,6 @@ import android.util.Log
 import android.widget.Toast
 import dji.sampleV5.aircraft.control.PachKeyManager
 import dji.sampleV5.aircraft.defaultlayout.DefaultLayoutActivity
-import dji.sampleV5.aircraft.telemetry.TuskServiceWebsocket
 import dji.sampleV5.modulecommon.DJIMainActivity
 import dji.v5.common.utils.GeoidManager
 import dji.v5.manager.datacenter.livestream.StreamQuality
@@ -22,13 +21,19 @@ import dji.v5.ux.sample.showcase.widgetlist.WidgetsActivity
  * Copyright (c) 2022, DJI All Rights Reserved.
  */
 class DJIAircraftMainActivity : DJIMainActivity() {
-    private val TuskManger = PachKeyManager()
+    val TuskManger = PachKeyManager()
     override fun prepareUxActivity() {
         UxSharedPreferencesUtil.initialize(this)
         GlobalPreferencesManager.initialize(DefaultGlobalPreferences(this))
         GeoidManager.getInstance().init(this)
 
-        enableDefaultLayout(DefaultLayoutActivity::class.java) // important
+        if (TuskManger != null) {
+            enableDefaultLayout(DefaultLayoutActivity::class.java) // important
+        }
+        else {
+            enableDefaultLayout(DefaultLayoutActivity::class.java) // important
+        }
+
         enableWidgetList(WidgetsActivity::class.java)
         this.TuskManger.runTesting()
 //        prepareConfigurationTools()

--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/control/PachKeyManager.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/control/PachKeyManager.kt
@@ -35,6 +35,38 @@ import kotlin.math.sin
 import kotlin.math.sqrt
 
 class PachKeyManager() {
+    /*
+    * The companion object brackets are used to essentially create a singleton object,
+    * where when the PachKeyManager class is called the first time, it creates an instance
+    * of the class. But, when PachKeyManager is called again, it will return the same
+    * instance of that object, effectively making it so that there is only one instance
+    * of PachKeyManager running at anytime, and can be referenced from any activity.
+    *
+    * Explanation of code:
+    * - @Volitile indicates that when something about the object is changed, it is reflected
+    * in all other threads.
+    * - getInstance() initially checks if the instance is null, and if it's not,
+    * create an instance.
+    *
+    * - synchronized(this){} prevents multiple threads from excecuting the block of code at
+    * at the same time. That means, only one thread can create the instance.
+    *
+    * - inside the synchronized block it checks again if instance is null, and if not, creates
+    * an instance of PachKeyManager, and sets instance equal to it.
+    *
+    * This code was a ChatGPT suggestion - while it works for the testing I've done with it,
+    * I'm wondering if this is in accordance with some of the best practices for android dev.
+    *
+    * */
+    companion object {
+        @Volatile
+        private var instance: PachKeyManager? = null
+        fun getInstance(): PachKeyManager {
+            return instance ?: synchronized(this) {
+                instance ?: PachKeyManager().also { instance = it }
+            }
+        }
+    }
     // Initialize necessary classes
     val telemService = TuskServiceWebsocket()
     private var controller = VirtualStickControl()
@@ -156,7 +188,7 @@ class PachKeyManager() {
         telemService.postAutonomyStatus(Event(status))
     }
 
-    private fun sendStreamURL(url: String) {
+    fun sendStreamURL(url: String) {
         telemService.postStreamURL(StreamInfo(url))
         Log.v("PachKeyManager", "Stream URL: $url")
     }

--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
@@ -25,6 +25,7 @@ package dji.sampleV5.aircraft.defaultlayout;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
@@ -32,10 +33,12 @@ import android.widget.Button;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import dji.sampleV5.aircraft.BuildConfig;
+import dji.sampleV5.aircraft.control.PachKeyManager;
 import dji.sampleV5.aircraft.video.StreamManager;
 import dji.sdk.keyvalue.value.common.CameraLensType;
 import dji.sdk.keyvalue.value.common.ComponentIndexType;
@@ -77,7 +80,7 @@ import dji.v5.ux.visualcamera.CameraVisiblePanelWidget;
 import dji.v5.ux.visualcamera.zoom.FocalZoomWidget;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
-//import dji.sampleV5.aircraft.control.PachKeyManager;
+import dji.sampleV5.aircraft.DJIAircraftMainActivity;
 
 /**
  * Displays a sample layout of widgets similar to that of the various DJI apps.
@@ -118,8 +121,7 @@ public class DefaultLayoutActivity extends AppCompatActivity {
     private VideoChannelStateChangeListener secondaryChannelStateListener = null;
     private Button liveStreamButton;
     private Button mapExpand;
-
-//    private PachKeyManager pachManager;
+    private PachKeyManager pachManager;
     //endregion
 
     //region Lifecycle
@@ -150,14 +152,13 @@ public class DefaultLayoutActivity extends AppCompatActivity {
 
         mapWidget = findViewById(R.id.widget_map);
         cameraControlsWidget.getExposureSettingsIndicatorWidget().setStateChangeResourceId(R.id.panel_camera_controls_exposure_settings);
-
 //        ViewStub stub = findViewById(R.id.manual_right_nav_setting_stub);
 //        if (stub != null) {
 //            mSettingPanelWidget = (SettingPanelWidget) stub.inflate();
 //        }
         mapExpand = (Button) findViewById(R.id.button_expand_map);
         liveStreamButton = (Button) findViewById(R.id.myLiveStream) ;
-        streamManager = new StreamManager();
+//        streamManager = new StreamManager();
 //        streamManager.setStreamSettings(SOME STREAM SETTINGS DEFINED IN MAIN ACT HERE);
 //        streamManager.set()
         initClickListener();
@@ -181,6 +182,9 @@ public class DefaultLayoutActivity extends AppCompatActivity {
 //            }
 //        });
         mapWidget.onCreate(savedInstanceState);
+        Log.d("PachKeyManager", "We got to DefaultLayout");
+        pachManager = new PachKeyManager(); // points to object created in DJIAircraftMainActivity
+        streamManager = pachManager.getStreamer(); // sets the streamManager to the streamer in Pach
     }
 
     private void initClickListener() {
@@ -207,7 +211,8 @@ public class DefaultLayoutActivity extends AppCompatActivity {
                 @Override
                 public void onClick(View view) {
                     streamManager.startStream();
-//                    pachManager.sendStreamURL(streamManager.getStreamURL());
+//                    sendStreamURL(streamManager.getStreamURL())
+                    pachManager.sendStreamURL(streamManager.getStreamURL());
                     if (streamManager.isStreaming()) {
                         liveStreamButton.setBackgroundResource(R.drawable.uxsdk_livestream_stop);
                     }

--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
@@ -182,7 +182,6 @@ public class DefaultLayoutActivity extends AppCompatActivity {
 //            }
 //        });
         mapWidget.onCreate(savedInstanceState);
-        Log.d("PachKeyManager", "We got to DefaultLayout");
         pachManager = new PachKeyManager(); // points to object created in DJIAircraftMainActivity
         streamManager = pachManager.getStreamer(); // sets the streamManager to the streamer in Pach
     }

--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
@@ -32,8 +32,6 @@ import android.widget.Button;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
-
-import java.io.Serializable;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
@@ -80,7 +78,6 @@ import dji.v5.ux.visualcamera.CameraVisiblePanelWidget;
 import dji.v5.ux.visualcamera.zoom.FocalZoomWidget;
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers;
 import io.reactivex.rxjava3.disposables.CompositeDisposable;
-import dji.sampleV5.aircraft.DJIAircraftMainActivity;
 
 /**
  * Displays a sample layout of widgets similar to that of the various DJI apps.
@@ -158,9 +155,6 @@ public class DefaultLayoutActivity extends AppCompatActivity {
 //        }
         mapExpand = (Button) findViewById(R.id.button_expand_map);
         liveStreamButton = (Button) findViewById(R.id.myLiveStream) ;
-//        streamManager = new StreamManager();
-//        streamManager.setStreamSettings(SOME STREAM SETTINGS DEFINED IN MAIN ACT HERE);
-//        streamManager.set()
         initClickListener();
         MediaDataCenter.getInstance().getVideoStreamManager().addStreamSourcesListener(sources -> runOnUiThread(() -> updateFPVWidgetSource(sources)));
         primaryFpvWidget.setOnFPVStreamSourceListener((devicePosition, lensType) -> {

--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/telemetry/TuskServiceWebsocket.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/telemetry/TuskServiceWebsocket.kt
@@ -6,8 +6,9 @@ import dji.v5.utils.common.ToastUtils
 import okhttp3.*
 import okio.ByteString
 import org.json.JSONObject
+import java.io.Serializable
 
-class TuskServiceWebsocket{
+class TuskServiceWebsocket {
     private val client: OkHttpClient = OkHttpClient()
     private lateinit var webSocket: WebSocket
     private val gson: Gson = Gson()

--- a/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/java/dji/sampleV5/modulecommon/DJIMainActivity.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/java/dji/sampleV5/modulecommon/DJIMainActivity.kt
@@ -59,7 +59,6 @@ abstract class DJIMainActivity : AppCompatActivity(), ITuskServiceCallback, IStr
     protected val msdkInfoVm: MSDKInfoVm by viewModels()
     private val handler: Handler = Handler(Looper.getMainLooper())
 
-    //    private val reconnectStream: Button = reconnect_ws
     abstract fun prepareUxActivity()
 
     abstract fun prepareTestingToolsActivity()
@@ -80,7 +79,6 @@ abstract class DJIMainActivity : AppCompatActivity(), ITuskServiceCallback, IStr
     private fun initOnClickListeners() {
         // Set onClickListener for wsButton
         reconnect_ws.setOnClickListener {
-            Log.d("TuskService", "Button Pressed?")
             setStatus(1, serverStatus)
             callReconnectWebsocket()
             if (callGetConnectionStatus()) {
@@ -92,7 +90,6 @@ abstract class DJIMainActivity : AppCompatActivity(), ITuskServiceCallback, IStr
         }
 
         reconnect_ws_settings.setOnClickListener {
-            Log.d("TuskService", "Button Pressed?")
             setStatus(1, serverStatus)
             callReconnectWebsocket()
             if (callGetConnectionStatus()) {
@@ -202,7 +199,6 @@ abstract class DJIMainActivity : AppCompatActivity(), ITuskServiceCallback, IStr
         registerApp()
         prepareTestingToolsActivity()
         startStatusCheck()
-//        initMSDKInfoView() // needed to keep pairing?
     }
 
     @SuppressLint("SetTextI18n")
@@ -218,30 +214,6 @@ abstract class DJIMainActivity : AppCompatActivity(), ITuskServiceCallback, IStr
         baseMainActivityVm.registerState.observe(this) {
             text_view_registered.text = StringUtils.getResStr(R.string.registration_status, it)
         }
-//        baseMainActivityVm.sdkNews.observe(this) {
-//            item_news_msdk.setTitle(StringUtils.getResStr(it.title))
-//            item_news_msdk.setDescription(StringUtils.getResStr(it.description))
-//            item_news_msdk.setDate(it.date)
-//
-//            item_news_uxsdk.setTitle(StringUtils.getResStr(it.title))
-//            item_news_uxsdk.setDescription(StringUtils.getResStr(it.description))
-//            item_news_uxsdk.setDate(it.date)
-//        }
-//
-//        icon_sdk_forum.setOnClickListener {
-//            Helper.startBrowser(this, StringUtils.getResStr(R.string.sdk_forum_url))
-//        }
-//        icon_release_node.setOnClickListener {
-//            Helper.startBrowser(this, StringUtils.getResStr(R.string.release_node_url))
-//        }
-//        icon_tech_support.setOnClickListener {
-//            Helper.startBrowser(this, StringUtils.getResStr(R.string.tech_support_url))
-//        }
-//        view_base_info.setOnClickListener {
-//            baseMainActivityVm.doPairing {
-//                ToastUtils.showToast(it)
-//            }
-//        }
     }
 
     private fun registerApp() {

--- a/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/java/dji/sampleV5/modulecommon/DJIMainActivity.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/java/dji/sampleV5/modulecommon/DJIMainActivity.kt
@@ -20,7 +20,6 @@ import android.widget.ImageView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.text.set
 import dji.sampleV5.modulecommon.models.BaseMainActivityVm
 import dji.sampleV5.modulecommon.models.MSDKInfoVm
 import dji.sampleV5.modulecommon.util.IStreamManager
@@ -34,6 +33,8 @@ import dji.v5.utils.common.PermissionUtil
 import dji.v5.utils.common.StringUtils
 import dji.v5.utils.common.ToastUtils
 import kotlinx.android.synthetic.main.activity_main.*
+import java.io.Serializable
+
 /**
  * Class Description
  *
@@ -167,6 +168,10 @@ abstract class DJIMainActivity : AppCompatActivity(), ITuskServiceCallback, IStr
             settings_panel.visibility = View.VISIBLE
         }
 
+        settings_panel.setOnClickListener {
+            // do nothing, leave here so that touch events are absorbed
+        }
+
         close_button.setOnClickListener {
             settings_panel.visibility = View.INVISIBLE
         }
@@ -279,6 +284,9 @@ abstract class DJIMainActivity : AppCompatActivity(), ITuskServiceCallback, IStr
     }
 
 
+    fun <T> enableDefaultLayout(cl: Class<T>, obj: Any) {
+        enableShowCaseButton(default_layout_button, cl)
+    }
     fun <T> enableDefaultLayout(cl: Class<T>) {
         enableShowCaseButton(default_layout_button, cl)
     }
@@ -304,6 +312,18 @@ abstract class DJIMainActivity : AppCompatActivity(), ITuskServiceCallback, IStr
         view.setOnClickListener {
             Intent(this, cl).also {
                 startActivity(it)
+            }
+        }
+    }
+
+    // overloaded function needed to pass Pach instance to defaultLayout
+    private fun <T> enableShowCaseButton(view: View, cl: Class<T>, obj: Serializable) {
+        view.isEnabled = true
+        view.setOnClickListener {
+            Intent(view.context, cl).also { intent ->
+                intent.putExtra("objectKey", obj)
+                Log.d("PachKeyManager", "About to start DefaultLayout")
+                view.context.startActivity(intent)
             }
         }
     }
@@ -368,6 +388,7 @@ abstract class DJIMainActivity : AppCompatActivity(), ITuskServiceCallback, IStr
 
     private val statusCheckRunnable = object : Runnable {
         override fun run() {
+            Log.d("TuskService", "Status Panel Height: ${status_panel.height}")
             if (callGetConnectionStatus()) {
                 setStatus(1, serverStatus)
             }

--- a/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/res/layout/activity_main.xml
+++ b/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/res/layout/activity_main.xml
@@ -52,7 +52,8 @@
                 android:padding="16dp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent">
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintBottom_toBottomOf="parent">
 
                 <ImageView
                     android:layout_width="wrap_content"

--- a/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/res/layout/activity_main.xml
+++ b/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/res/layout/activity_main.xml
@@ -89,7 +89,7 @@
                     android:layout_height="wrap_content"
                     android:foreground="?selectableItemBackground"
                     android:layout_marginLeft="8dp"
-                    android:layout_marginTop="80dp"
+                    android:layout_marginTop="70dp"
                     android:layout_marginRight="8dp"
                     android:background="@drawable/rounded_gray_bg"
                     android:enabled="true"
@@ -180,15 +180,12 @@
                         android:layout_width="40dp"
                         android:layout_height="40dp"
                         app:srcCompat="@drawable/airplane_tilt_fill"
-                        android:layout_marginEnd="10dp"
-                        android:layout_marginTop="10dp"
                         app:layout_constraintRight_toRightOf="parent"
                         app:layout_constraintVertical_chainStyle="spread"
                         app:layout_constraintLeft_toRightOf="@+id/imageDot2"
                         app:layout_constraintBottom_toBottomOf="parent"
                         app:layout_constraintTop_toTopOf="parent"/>
                 </androidx.constraintlayout.widget.ConstraintLayout>
-
             </LinearLayout>
             <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/fpv/FPVWidget.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/core/widget/fpv/FPVWidget.kt
@@ -60,6 +60,7 @@ import dji.v5.ux.core.util.RxUtil
 import dji.v5.ux.core.widget.fpv.FPVWidget.ModelState
 import io.reactivex.rxjava3.core.Flowable
 import io.reactivex.rxjava3.functions.Consumer
+import kotlinx.android.synthetic.main.uxsdk_view_widget.view.textview_aspect_ratio
 
 private const val TAG = "FPVWidget"
 private const val ORIGINAL_SCALE = 1f
@@ -98,7 +99,7 @@ open class FPVWidget @JvmOverloads constructor(
     /**
      * Whether the video feed source's camera name is visible on the video feed.
      */
-    var isCameraSourceNameVisible = true
+    var isCameraSourceNameVisible = false
         set(value) {
             field = value
             checkAndUpdateCameraName()
@@ -108,7 +109,7 @@ open class FPVWidget @JvmOverloads constructor(
      * Whether the video feed source's camera side is visible on the video feed.
      * Only shown on aircraft that support multiple gimbals.
      */
-    var isCameraSourceSideVisible = true
+    var isCameraSourceSideVisible = false
         set(value) {
             field = value
             checkAndUpdateCameraSide()
@@ -362,6 +363,7 @@ open class FPVWidget @JvmOverloads constructor(
     //region Customization
     override fun getIdealDimensionRatioString(): String {
         return getString(R.string.uxsdk_widget_fpv_ratio)
+//        return fpvSurfaceView.textview_aspect_ratio.toString()
     }
 
     fun updateVideoSource(source: StreamSource, channelType: VideoChannelType) {
@@ -428,7 +430,7 @@ open class FPVWidget @JvmOverloads constructor(
     private fun updateCameraName(cameraName: String) {
         cameraNameTextView.text = cameraName
         if (cameraName.isNotEmpty() && isCameraSourceNameVisible) {
-            cameraNameTextView.visibility = View.VISIBLE
+            cameraNameTextView.visibility = View.INVISIBLE
         } else {
             cameraNameTextView.visibility = View.INVISIBLE
         }
@@ -437,7 +439,7 @@ open class FPVWidget @JvmOverloads constructor(
     private fun updateCameraSide(cameraSide: String) {
         cameraSideTextView.text = cameraSide
         if (cameraSide.isNotEmpty() && isCameraSourceSideVisible) {
-            cameraSideTextView.visibility = View.VISIBLE
+            cameraSideTextView.visibility = View.INVISIBLE
         } else {
             cameraSideTextView.visibility = View.INVISIBLE
         }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/values/strings_dimension_ratios.xml
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/values/strings_dimension_ratios.xml
@@ -34,6 +34,7 @@
     <string name="uxsdk_widget_dashboard_ratio" translatable="false">W,476:91</string>
     <string name="uxsdk_widget_flight_mode_ratio" translatable="false">W,52:11</string>
     <string name="uxsdk_widget_fpv_ratio" translatable="false">W,16:9</string>
+    <string name="uxsdk_widget_fpv_wide_ratio" translatable="false">W,4:3</string>
     <string name="uxsdk_widget_radar_ratio" translatable="false">W,17:8</string>
     <string name="uxsdk_widget_user_account_login_ratio" translatable="false">W,4:1</string>
     <string name="uxsdk_widget_remaining_flight_time_ratio" translatable="false">W,400:3</string>


### PR DESCRIPTION
The following bug fixes were made:
- When the startLiveStream button is clicked in defaultLayoutActivity, it no longer requires the pressing of a key to activate the stream. Done using a singleton PachKeyManager object (see comments in code)
- Settings panel no longer allows users to click buttons hidden behind the panel using an onClickListener
- Status indicator is no longer cut off when returning to DJIMainActivity from defaultLayoutActivity

During development some new bugs were discovered:
- When the livestream settings panel is opened, the selection of the stream quality is based on the button press, not the observed stream quality.
- When the camera mode is changed to "photo mode", the FPVWidget expands the camera stream such that it fills the entire screen and is stretched. This does not affect the photos taken, just how it looks in the app.