### PR TITLE
Status indicator devel

### DIFF
--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/DJIAircraftMainActivity.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/DJIAircraftMainActivity.kt
@@ -36,7 +36,7 @@ class DJIAircraftMainActivity : DJIMainActivity() {
 
         enableWidgetList(WidgetsActivity::class.java)
         this.TuskManger.runTesting()
-        this.TuskManger.checkForWaypoints()
+        this.TuskManger.updateStatusWidget()
 //        prepareConfigurationTools()
 //
 

--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/DJIAircraftMainActivity.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/DJIAircraftMainActivity.kt
@@ -36,6 +36,7 @@ class DJIAircraftMainActivity : DJIMainActivity() {
 
         enableWidgetList(WidgetsActivity::class.java)
         this.TuskManger.runTesting()
+        this.TuskManger.checkForWaypoints()
 //        prepareConfigurationTools()
 //
 

--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/control/PachKeyManager.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/control/PachKeyManager.kt
@@ -149,7 +149,7 @@ class PachKeyManager() {
 //        streamer.startStream()
     }
 
-    fun checkForWaypoints() {
+    fun updateStatusWidget() {
         // Function checks if there are any waypoints in the waypoint list
         // If there are, it will follow the waypoints
         mainScope.launch {

--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/control/PachKeyManager.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/control/PachKeyManager.kt
@@ -77,12 +77,17 @@ class PachKeyManager() {
     }
     // Initialize necessary classes
     private var pachModel: PachWidgetModel = PachWidgetModel.getInstance()
-    var listener: WaypointListener? = null
+//    var listener: WaypointListener? = null
     val telemService = TuskServiceWebsocket()
+
+    /**
+     * Safety Failures, action, autonomous, and safety warnings are all used for the PachWidget
+     * to display the current status of the aircraft. These need to be moved to the datastructures
+     * file, in order to keep the code consistent and clean.
+     */
     private var safetyFailures: Array<Int> = arrayOf(0,0,0,0,0)
     private var action: String = ""
     private var autonomous: Boolean = false
-    private var endOfFlight: Boolean = false
     private val safetyWarnings = mapOf(
         0 to "Aircraft Not Flying",
         1 to "Go Home Button is pressed",
@@ -150,8 +155,8 @@ class PachKeyManager() {
     }
 
     fun updateStatusWidget() {
-        // Function checks if there are any waypoints in the waypoint list
-        // If there are, it will follow the waypoints
+        // Function updates the status widget with the current status of the aircraft, including
+        // connection status, autonomous/manual status, and any warnings that may be present
         mainScope.launch {
             var status = ""
             var prevWaypoint = Coordinate(0.0,0.0,0.0)
@@ -186,13 +191,13 @@ class PachKeyManager() {
         }
     }
 
-    fun setWaypointListener(listener: WaypointListener) {
-        this.listener = listener
-    }
-
-    fun isWaypointListenerSet(): Boolean {
-        return this.listener != null
-    }
+//    fun setWaypointListener(listener: WaypointListener) {
+//        this.listener = listener
+//    }
+//
+//    fun isWaypointListenerSet(): Boolean {
+//        return this.listener != null
+//    }
     fun runTesting() {
         KeyManager.getInstance().listen(fiveDKey, this) { _, newValue ->
             mainScope.launch {
@@ -905,7 +910,7 @@ class PachKeyManager() {
                 Log.v("PachKeyManagerHIPPO", "Unknown Decision Check Failed")
                 break
             }
-            this@PachKeyManager.action = ""
+            this@PachKeyManager.action = "" // if no action is taken, reset action to empty string
 
             // Handle logic for updating waypoint
             if (telemService.isGatherAction){
@@ -936,7 +941,7 @@ class PachKeyManager() {
                     Log.v("PachKeyManagerHIPPO", "Waypoint Not Updated")
                 }
             }
-            this@PachKeyManager.action = ""
+            this@PachKeyManager.action = "" // if no action is taken, reset action to empty string
         }
         controller.endVirtualStick()
     }
@@ -1098,10 +1103,10 @@ class PachKeyManager() {
         }
     }
 
-    interface WaypointListener {
-        fun onReachedWaypoint()
-        fun onUpdatedWaypoints()
-    }
+//    interface WaypointListener {
+//        fun onReachedWaypoint()
+//        fun onUpdatedWaypoints()
+//    }
 
 //    override fun getConnectionStatus(): Boolean {
 //        return this.telemService.getConnectionStatus()

--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
@@ -72,6 +72,8 @@ import dji.v5.ux.core.widget.simulator.SimulatorIndicatorWidget;
 import dji.v5.ux.core.widget.systemstatus.SystemStatusWidget;
 import dji.v5.ux.map.MapWidget;
 import dji.v5.ux.mapkit.core.maps.DJIMap;
+import dji.v5.ux.pachWidget.PachWidget;
+import dji.v5.ux.pachWidget.PachWidgetModel;
 import dji.v5.ux.training.simulatorcontrol.SimulatorControlWidget;
 import dji.v5.ux.visualcamera.CameraNDVIPanelWidget;
 import dji.v5.ux.visualcamera.CameraVisiblePanelWidget;
@@ -107,6 +109,7 @@ public class DefaultLayoutActivity extends AppCompatActivity {
     protected MapWidget mapWidget;
     protected TopBarPanelWidget topBarPanel;
     protected StreamManager streamManager;
+    protected PachWidget pachWidget;
 //    private SettingPanelWidget mSettingPanelWidget;
 //    private DrawerLayout mDrawerLayout;
 
@@ -147,7 +150,7 @@ public class DefaultLayoutActivity extends AppCompatActivity {
         focalZoomWidget = findViewById(R.id.widget_focal_zoom);
         cameraControlsWidget = findViewById(R.id.widget_camera_controls);
         horizontalSituationIndicatorWidget = findViewById(R.id.widget_horizontal_situation_indicator);
-
+        pachWidget = findViewById(R.id.pach_widget);
         mapWidget = findViewById(R.id.widget_map);
         cameraControlsWidget.getExposureSettingsIndicatorWidget().setStateChangeResourceId(R.id.panel_camera_controls_exposure_settings);
 //        ViewStub stub = findViewById(R.id.manual_right_nav_setting_stub);

--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
@@ -439,6 +439,7 @@ public class DefaultLayoutActivity extends AppCompatActivity {
 
         //只在部分len下显示
         ndviCameraPanel.setVisibility(CameraUtil.isSupportForNDVI(lensType) ? View.VISIBLE : View.INVISIBLE);
+        visualCameraPanel.setVisibility(View.INVISIBLE);
     }
 
     /**

--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/defaultlayout/DefaultLayoutActivity.java
@@ -103,7 +103,7 @@ public class DefaultLayoutActivity extends AppCompatActivity {
     protected ExposureSettingsPanel exposureSettingsPanel;
     protected PrimaryFlightDisplayWidget pfvFlightDisplayWidget;
     protected CameraNDVIPanelWidget ndviCameraPanel;
-    protected CameraVisiblePanelWidget visualCameraPanel;
+//    protected CameraVisiblePanelWidget visualCameraPanel;
     protected FocalZoomWidget focalZoomWidget;
     protected SettingWidget settingWidget;
     protected MapWidget mapWidget;
@@ -141,7 +141,7 @@ public class DefaultLayoutActivity extends AppCompatActivity {
         simulatorControlWidget = findViewById(R.id.widget_simulator_control);
         lensControlWidget = findViewById(R.id.widget_lens_control);
         ndviCameraPanel = findViewById(R.id.panel_ndvi_camera);
-        visualCameraPanel = findViewById(R.id.panel_visual_camera);
+//        visualCameraPanel = findViewById(R.id.panel_visual_camera);
         autoExposureLockWidget = findViewById(R.id.widget_auto_exposure_lock);
         focusModeWidget = findViewById(R.id.widget_focus_mode);
         focusExposureSwitchWidget = findViewById(R.id.widget_focus_exposure_switch);
@@ -391,9 +391,9 @@ public class DefaultLayoutActivity extends AppCompatActivity {
         if (ndviCameraPanel.getVisibility() == View.VISIBLE) {
             ndviCameraPanel.updateCameraSource(cameraIndex, lensType);
         }
-        if (visualCameraPanel.getVisibility() == View.VISIBLE) {
-            visualCameraPanel.updateCameraSource(cameraIndex, lensType);
-        }
+//        if (visualCameraPanel.getVisibility() == View.VISIBLE) {
+//            visualCameraPanel.updateCameraSource(cameraIndex, lensType);
+//        }
         if (autoExposureLockWidget.getVisibility() == View.VISIBLE) {
             autoExposureLockWidget.updateCameraSource(cameraIndex, lensType);
         }
@@ -424,7 +424,7 @@ public class DefaultLayoutActivity extends AppCompatActivity {
         //fpv下不显示
         lensControlWidget.setVisibility(devicePosition == PhysicalDevicePosition.NOSE ? View.INVISIBLE : View.VISIBLE);
         ndviCameraPanel.setVisibility(devicePosition == PhysicalDevicePosition.NOSE ? View.INVISIBLE : View.VISIBLE);
-        visualCameraPanel.setVisibility(devicePosition == PhysicalDevicePosition.NOSE ? View.INVISIBLE : View.VISIBLE);
+//        visualCameraPanel.setVisibility(devicePosition == PhysicalDevicePosition.NOSE ? View.INVISIBLE : View.VISIBLE);
         autoExposureLockWidget.setVisibility(devicePosition == PhysicalDevicePosition.NOSE ? View.INVISIBLE : View.VISIBLE);
         focusModeWidget.setVisibility(devicePosition == PhysicalDevicePosition.NOSE ? View.INVISIBLE : View.VISIBLE);
         focusExposureSwitchWidget.setVisibility(devicePosition == PhysicalDevicePosition.NOSE ? View.INVISIBLE : View.VISIBLE);
@@ -439,7 +439,7 @@ public class DefaultLayoutActivity extends AppCompatActivity {
 
         //只在部分len下显示
         ndviCameraPanel.setVisibility(CameraUtil.isSupportForNDVI(lensType) ? View.VISIBLE : View.INVISIBLE);
-        visualCameraPanel.setVisibility(View.INVISIBLE);
+//        visualCameraPanel.setVisibility(View.INVISIBLE);
     }
 
     /**

--- a/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/java/dji/sampleV5/modulecommon/DJIMainActivity.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/java/dji/sampleV5/modulecommon/DJIMainActivity.kt
@@ -344,7 +344,7 @@ abstract class DJIMainActivity : AppCompatActivity(), ITuskServiceCallback, IStr
 
     override fun onPause() {
         super.onPause()
-        stopStatusCheck() // Stop the status checking coroutine when the activity is paused
+//        stopStatusCheck() // Stop the status checking coroutine when the activity is paused
         removeSettingsPageOverlay()
     }
 

--- a/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/res/layout/activity_main.xml
+++ b/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/res/layout/activity_main.xml
@@ -397,7 +397,7 @@
                 android:enabled="true"
                 android:gravity="center"
                 android:padding="8dp"
-                android:text="Pair Drone"
+                android:text="Piar Drone"
                 android:textColor="@color/selector_enable_button" />
 <!--            <Button-->
 <!--                android:id="@+id/live_stream_shortcut"-->

--- a/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/res/layout/activity_main.xml
+++ b/SampleCode-V5/android-sdk-v5-sample/module-common/src/main/res/layout/activity_main.xml
@@ -397,7 +397,7 @@
                 android:enabled="true"
                 android:gravity="center"
                 android:padding="8dp"
-                android:text="Piar Drone"
+                android:text="Pair Drone"
                 android:textColor="@color/selector_enable_button" />
 <!--            <Button-->
 <!--                android:id="@+id/live_stream_shortcut"-->

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/pachWidget/IPachWidgetModel.kt
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/pachWidget/IPachWidgetModel.kt
@@ -1,0 +1,7 @@
+package dji.v5.ux.pachWidget
+
+interface IPachWidgetModel {
+    fun getConnectionStatus(): Boolean
+    fun getFailedSafetyCheck(): Array<Int>
+    fun getAction(): String
+}

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/pachWidget/PachWidget.java
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/pachWidget/PachWidget.java
@@ -1,13 +1,7 @@
 package dji.v5.ux.pachWidget;
 
 import android.content.Context;
-import android.graphics.Paint;
 import android.util.AttributeSet;
-import android.util.Log;
-import android.view.LayoutInflater;
-import android.view.View;
-import android.view.animation.Animation;
-import android.view.animation.TranslateAnimation;
 import android.widget.ImageView;
 import android.widget.TextView;
 
@@ -16,18 +10,19 @@ import androidx.annotation.Nullable;
 import androidx.lifecycle.LifecycleOwner;
 
 import dji.v5.ux.R;
-import dji.v5.ux.core.base.DJISDKModel;
 import dji.v5.ux.core.base.widget.ConstraintLayoutWidget;
-import dji.v5.ux.core.communication.ObservableInMemoryKeyedStore;
-import io.reactivex.BackpressureStrategy;
-import io.reactivex.rxjava3.core.Flowable;
+/**
+ * PachWidget displays the state of the SAFARI system, including
+ * the connection status to the SAFARI system and the flight state
+ * of the drone (whether it is autonomous or manual), and actions
+ * associated with the state of the drone.
+ */
 
 public class PachWidget extends ConstraintLayoutWidget<Object> {
     private PachWidgetModel pachWidgetModel;
     private IPachWidgetModel pach;
     private TextView msg;
     private ImageView connection;
-//    private Flowable<String> msgDataFlowable;
     public PachWidget(@NonNull Context context) {
         super(context);
     }
@@ -38,12 +33,6 @@ public class PachWidget extends ConstraintLayoutWidget<Object> {
 
     public PachWidget(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-    }
-
-    public float getTextWidth(String text, float textSize) {
-        Paint paint = new Paint();
-        paint.setTextSize(textSize);
-        return paint.measureText(text);
     }
 
     @Override
@@ -59,16 +48,11 @@ public class PachWidget extends ConstraintLayoutWidget<Object> {
     protected void reactToModelChanges() {
         pachWidgetModel.msgdata.observe((LifecycleOwner) getContext(), msgData -> {
             msg.setText(msgData);
-//            if (getTextWidth(msgData, msg.getTextSize()) > getResources().getDimensionPixelSize(R.dimen.uxsdk_200_dp)) {
-//                msg.setSelected(true);
-//            } else {
-//                msg.setSelected(false);
-//            }
         });
-        pachWidgetModel.connectiondata.observe((LifecycleOwner) getContext(), connectionData -> {
-            if (connectionData) {
+        pachWidgetModel.connectiondata.observe((LifecycleOwner) getContext(), connected -> {
+            if (connected) {
                 connection.setImageResource(R.drawable.uxsdk_ic_alert_good);
-            } else if (!connectionData) {
+            } else if (!connected) {
                 connection.setImageResource(R.drawable.uxsdk_ic_alert_error);
             }
         });

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/pachWidget/PachWidget.java
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/pachWidget/PachWidget.java
@@ -1,0 +1,83 @@
+package dji.v5.ux.pachWidget;
+
+import android.content.Context;
+import android.graphics.Paint;
+import android.util.AttributeSet;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.animation.Animation;
+import android.view.animation.TranslateAnimation;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.lifecycle.LifecycleOwner;
+
+import dji.v5.ux.R;
+import dji.v5.ux.core.base.DJISDKModel;
+import dji.v5.ux.core.base.widget.ConstraintLayoutWidget;
+import dji.v5.ux.core.communication.ObservableInMemoryKeyedStore;
+import io.reactivex.BackpressureStrategy;
+import io.reactivex.rxjava3.core.Flowable;
+
+public class PachWidget extends ConstraintLayoutWidget<Object> {
+    private PachWidgetModel pachWidgetModel;
+    private IPachWidgetModel pach;
+    private TextView msg;
+    private ImageView connection;
+//    private Flowable<String> msgDataFlowable;
+    public PachWidget(@NonNull Context context) {
+        super(context);
+    }
+
+    public PachWidget(@NonNull Context context, @Nullable AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    public PachWidget(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+    }
+
+    public float getTextWidth(String text, float textSize) {
+        Paint paint = new Paint();
+        paint.setTextSize(textSize);
+        return paint.measureText(text);
+    }
+
+    @Override
+    protected void initView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        inflate(context, R.layout.uxsdk_widget_pach, this);
+        pachWidgetModel = pachWidgetModel.getInstance();
+        msg = findViewById(R.id.status_msg);
+        connection = findViewById(R.id.connection_icon);
+        msg.setSelected(true);
+    }
+
+    @Override
+    protected void reactToModelChanges() {
+        pachWidgetModel.msgdata.observe((LifecycleOwner) getContext(), msgData -> {
+            msg.setText(msgData);
+//            if (getTextWidth(msgData, msg.getTextSize()) > getResources().getDimensionPixelSize(R.dimen.uxsdk_200_dp)) {
+//                msg.setSelected(true);
+//            } else {
+//                msg.setSelected(false);
+//            }
+        });
+        pachWidgetModel.connectiondata.observe((LifecycleOwner) getContext(), connectionData -> {
+            if (connectionData) {
+                connection.setImageResource(R.drawable.uxsdk_ic_alert_good);
+            } else if (!connectionData) {
+                connection.setImageResource(R.drawable.uxsdk_ic_alert_error);
+            }
+        });
+    }
+
+    public void onCreate(IPachWidgetModel pach) {
+        this.pach = pach;
+        if (this.pach != null) {
+            pachWidgetModel.setPach(this.pach);
+        }
+    }
+}

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/pachWidget/PachWidgetModel.java
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/pachWidget/PachWidgetModel.java
@@ -1,0 +1,54 @@
+package dji.v5.ux.pachWidget;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.ViewModel;
+
+public class PachWidgetModel extends ViewModel{
+    private static PachWidgetModel instance = null;
+    private IPachWidgetModel pachKeyManager;
+    private MutableLiveData<String> _msgdata;
+    protected LiveData<String> msgdata;
+    private MutableLiveData<Boolean> _connectiondata;
+    protected LiveData<Boolean> connectiondata;
+    private PachWidgetModel() {
+        _msgdata = new MutableLiveData<>();
+        _connectiondata = new MutableLiveData<>();
+        msgdata = _msgdata;
+        connectiondata = _connectiondata;
+    }
+
+    public static synchronized PachWidgetModel getInstance() {
+        if (instance == null) {
+            instance = new PachWidgetModel();
+        }
+        return instance;
+    }
+
+    public LiveData<String> getMsgData() {
+        return msgdata;
+    }
+    public LiveData<Boolean> getConnectionData() {
+        return connectiondata;
+    }
+
+    public void updateMsg(String msg) {
+        _msgdata.setValue(msg);
+        msgdata = _msgdata;
+    }
+    public void updateConnection(Boolean connection) {
+        _connectiondata.setValue(connection);
+        connectiondata = _connectiondata;
+    }
+//    public void fetchData() {
+//        msgdata.postValue(pachKeyManager.getAction());
+//        connectiondata.postValue(pachKeyManager.getConnectionStatus());
+//    }
+
+    public void setPach(IPachWidgetModel pach) {
+        this.pachKeyManager = pach;
+//        if (this.pachKeyManager != null) {
+//            fetchData();
+//        }
+    }
+}

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/pachWidget/PachWidgetModel.java
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/pachWidget/PachWidgetModel.java
@@ -7,17 +7,23 @@ import androidx.lifecycle.ViewModel;
 public class PachWidgetModel extends ViewModel{
     private static PachWidgetModel instance = null;
     private IPachWidgetModel pachKeyManager;
-    private MutableLiveData<String> _msgdata;
-    protected LiveData<String> msgdata;
-    private MutableLiveData<Boolean> _connectiondata;
-    protected LiveData<Boolean> connectiondata;
-    private PachWidgetModel() {
+    private MutableLiveData<String> _msgdata; // updated by PachKeyManager
+    public LiveData<String> msgdata; // observable to Widgets
+    private MutableLiveData<Boolean> _connectiondata; // updated by PachKeyManager
+    public LiveData<Boolean> connectiondata; // observable to Widgets
+
+    private PachWidgetModel() { // constructor
         _msgdata = new MutableLiveData<>();
         _connectiondata = new MutableLiveData<>();
         msgdata = _msgdata;
         connectiondata = _connectiondata;
     }
 
+    // singleton pattern - only one instance of this class can exist. Many PachWidgets
+    // can use this instance to update the message and connection status, but they will
+    // reference the same instance of the model. This is useful because it allows for
+    // a single source of truth for the message and connection status, coming from the
+    // PachKeyManager class.
     public static synchronized PachWidgetModel getInstance() {
         if (instance == null) {
             instance = new PachWidgetModel();
@@ -25,13 +31,10 @@ public class PachWidgetModel extends ViewModel{
         return instance;
     }
 
-    public LiveData<String> getMsgData() {
-        return msgdata;
-    }
-    public LiveData<Boolean> getConnectionData() {
-        return connectiondata;
-    }
-
+    // update functions follow an encapsulation pattern, where the PachKeyManager class
+    // updates the MutableLiveData objects, and the Widgets observe the LiveData objects.
+    // This prevents the widgets from being able to change the data they get from the
+    // PachKeyManager, and ensures that the data is only updated by the PachKeyManager.
     public void updateMsg(String msg) {
         _msgdata.setValue(msg);
         msgdata = _msgdata;
@@ -40,15 +43,8 @@ public class PachWidgetModel extends ViewModel{
         _connectiondata.setValue(connection);
         connectiondata = _connectiondata;
     }
-//    public void fetchData() {
-//        msgdata.postValue(pachKeyManager.getAction());
-//        connectiondata.postValue(pachKeyManager.getConnectionStatus());
-//    }
 
     public void setPach(IPachWidgetModel pach) {
         this.pachKeyManager = pach;
-//        if (this.pachKeyManager != null) {
-//            fetchData();
-//        }
     }
 }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/layout/uxsdk_activity_default_layout.xml
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/layout/uxsdk_activity_default_layout.xml
@@ -142,13 +142,15 @@
             android:paddingRight="2dp"
             app:layout_constraintBottom_toBottomOf="@+id/widget_focus_exposure_switch"
             app:layout_constraintEnd_toStartOf="@+id/widget_auto_exposure_lock"
-            app:layout_constraintTop_toTopOf="@+id/widget_focus_exposure_switch" />
+            app:layout_constraintTop_toTopOf="@+id/widget_focus_exposure_switch"
+            android:visibility="invisible"/>
 
         <dji.v5.ux.cameracore.widget.autoexposurelock.AutoExposureLockWidget
             android:id="@+id/widget_auto_exposure_lock"
             android:layout_width="@dimen/uxsdk_camera_bar_height"
             android:layout_height="@dimen/uxsdk_camera_bar_height"
             android:layout_marginEnd="8dp"
+            android:layout_marginStart="8dp"
             android:padding="@dimen/uxsdk_camera_bar_padding"
             app:layout_constraintBottom_toBottomOf="@+id/widget_focus_exposure_switch"
             app:layout_constraintEnd_toStartOf="@+id/widget_focus_mode"
@@ -291,7 +293,16 @@
                 android:foreground="?selectableItemBackground"
                 android:padding="8dp"
                 tools:layout_editor_absoluteY="1387dp" />
-    </dji.v5.ux.map.MapWidget>
+         </dji.v5.ux.map.MapWidget>
+
+        <dji.v5.ux.pachWidget.PachWidget
+            android:id="@+id/pach_widget"
+            android:layout_width="wrap_content"
+            android:layout_height="@dimen/uxsdk_35_dp"
+            app:layout_constraintBottom_toBottomOf="@+id/widget_auto_exposure_lock"
+            app:layout_constraintEnd_toStartOf="@+id/widget_auto_exposure_lock"
+            android:padding="@dimen/uxsdk_0_6_dp"
+            android:layout_marginEnd="@dimen/uxsdk_8_dp"/>
 
         <dji.v5.ux.core.panel.systemstatus.SystemStatusListPanelWidget
             android:id="@+id/widget_panel_system_status_list"

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/layout/uxsdk_widget_pach.xml
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/res/layout/uxsdk_widget_pach.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:background="@drawable/uxsdk_background_black_rectangle">
+    <ImageView
+        android:id="@+id/connection_icon"
+        android:layout_width="30dp"
+        android:layout_height="30dp"
+        android:src="@drawable/uxsdk_fpv_hsi_compass_home_point"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintRight_toLeftOf="@id/status_msg"
+        android:paddingRight="@dimen/uxsdk_10_dp"
+        android:paddingLeft="@dimen/uxsdk_10_dp"/>
+    <TextView
+        android:id="@+id/status_msg"
+        android:layout_height="wrap_content"
+        android:layout_width="wrap_content"
+        android:ellipsize="marquee"
+        android:marqueeRepeatLimit="marquee_forever"
+        android:maxLines="1"
+        android:scrollHorizontally="true"
+        android:text="somemessage"
+        android:textSize="14sp"
+        android:textColor="@color/uxsdk_white"
+        app:layout_constraintLeft_toRightOf="@id/connection_icon"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:paddingRight="@dimen/uxsdk_10_dp"/>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Adds a status indicator widget to DefaulLayoutActivity. This pulls data from PachKeyManager via a coroutine, and publishes it to a widget called PachWidget. That widget displays that data.

Currently, that widget is only set up to take two primitive datatypes, a string and a bool. Those are used for the SAFARI related message that gets displayed, and the controller's connection status to SAFARI, respectively.