### PR TITLE
PID loop fix

### DIFF
--- a/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/control/PidController.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/app-aircraft/src/main/java/dji/sampleV5/aircraft/control/PidController.kt
@@ -20,6 +20,10 @@ class PidController(private val kp: Float, private val ki: Float, private val kd
         lastError = error
         return (kp * error) + (ki * integral) + (kd * derivative)
     }
+
+    fun resetIntegral() {
+        integral = 0.0
+    }
 //    fun calculateError(currentval: Double): Double {
 //        return (this.setpoint - currentval)
 //    }

--- a/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/map/MapWidget.java
+++ b/SampleCode-V5/android-sdk-v5-uxsdk/src/main/java/dji/v5/ux/map/MapWidget.java
@@ -483,14 +483,18 @@ public class MapWidget extends ConstraintLayoutWidget<Object> implements View.On
     // this function handles the data from the flowable. There should be
     // a maximum of one tusk waypoint at a time.
     protected void updateTuskTelemetryWaypoint(DJILatLng waypoint) {
+        if (waypoint == null) {
+            return; // no new data
+        }
         if (tuskMarker != null) {
-            tuskMarker.setPosition(waypoint);
-        } else {
-            // called when DJILatLong(0.0, 0.0) is sent from pachKeyManager
             if (!waypoint.isAvailable()) {
                 removeTuskTelemetryWaypoint();
+            } else {
+                tuskMarker.setPosition(waypoint);
             }
-            addTuskWaypointOnMap(waypoint);
+        } else {
+            // called when DJILatLong(0.0, 0.0) is sent from pachKeyManager
+            if (waypoint.isAvailable()) addTuskWaypointOnMap(waypoint);
         }
 
     }


### PR DESCRIPTION
Modified the values of the PID loop such that they are a little more reasonable. Using a single PID loop to control both the orbit and general waypoint navigation, only now the `ki` term is reset every time the drone reaches a defined waypoint. This prevents an accumulation of error as the PID loop runs, causing drastic overshoot. Flipped the sign of the latitude error found in `computeLatDistance`, since it would cause the drone to move in the opposite direction as intended.

Additionally, fixed a bug that would cause the Tusk Waypoints to go to 0,0 instead of being removed from the map, and cleaned up the waypoint logic such that it is managed directly by the `flyHippo` and `followWaypoints`.